### PR TITLE
feat(command): 为子命令添加独立权限控制

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,24 +130,32 @@
 
 ## 💻 命令系统
 
+### 权限节点
+
+| 权限节点 | 说明 | 默认许可 |
+|----------|------|----------|
+| `bilibili.video.use` | 玩家基础命令（qrcode/status/triple/reward） | 所有人 |
+| `bilibili.video.admin` | 管理员命令（unbind/credential/reload） | 仅 OP |
+
 ### 玩家命令
 
-| 命令 | 别名 | 功能 | 权限节点 |
-|------|------|------|----------|
-| `/bv help` | | 查看帮助信息 | `bilibili.command.help` |
-| `/bv qrcode` | | 生成 B 站登录二维码地图 | `bilibili.command.qrcode` |
-| `/bv status` | | 查看账号绑定状态 | `bilibili.command.status` |
-| `/bv triple <bvid>` | | 检测视频三连状态 | `bilibili.command.triple` |
-| `/bv reward <bvid>` | | 领取三连奖励 | `bilibili.command.reward` |
+| 命令 | 功能 | 权限节点 |
+|------|------|----------|
+| `/bv help` | 查看帮助信息 | `bilibili.video.use` |
+| `/bv qrcode` | 生成 B 站登录二维码地图 | `bilibili.video.use` |
+| `/bv status` | 查看账号绑定状态 | `bilibili.video.use` |
+| `/bv triple <bvid>` | 检测视频三连状态 | `bilibili.video.use` |
+| `/bv reward <bvid>` | 领取三连奖励 | `bilibili.video.use` |
 
 ### 管理员命令
 
 | 命令 | 功能 | 权限节点 |
 |------|------|----------|
-| `/bv admin reload` | 重载配置文件 | `bilibili.admin.reload` |
-| `/bv admin credential list` | 列出所有登录凭证 | `bilibili.admin.credential` |
-| `/bv admin credential info <label>` | 查看凭证详细信息 | `bilibili.admin.credential` |
-| `/bv admin credential refresh <label>` | 刷新指定凭证 | `bilibili.admin.credential` |
+| `/bv admin reload` | 重载配置文件 | `bilibili.video.admin` |
+| `/bv admin unbind <target>` | 解除玩家绑定（支持玩家名/UUID/B站UID） | `bilibili.video.admin` |
+| `/bv admin credential list` | 列出所有登录凭证 | `bilibili.video.admin` |
+| `/bv admin credential info <label>` | 查看凭证详细信息 | `bilibili.video.admin` |
+| `/bv admin credential refresh <label>` | 刷新指定凭证（待实现） | `bilibili.video.admin` |
 
 ### 🎮 使用示例
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=online.bingzi.bilibili.video
-version=2.0.3
+version=2.0.4

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/command/BilibiliVideoCommand.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/command/BilibiliVideoCommand.kt
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player
 import taboolib.common.platform.ProxyCommandSender
 import taboolib.common.platform.command.CommandBody
 import taboolib.common.platform.command.CommandHeader
+import taboolib.common.platform.command.PermissionDefault
 import taboolib.common.platform.command.mainCommand
 import taboolib.common.platform.command.subCommand
 import taboolib.common.platform.function.submit
@@ -29,8 +30,12 @@ import java.util.UUID
  * - /bv status      查看当前绑定状态与凭证信息
  * - /bv reward <bvid>  基于三连记录登记奖励
  * - /bv admin credential ... 管理/查看凭证
+ *
+ * 权限节点：
+ * - bilibili.video.use          玩家基础命令（qrcode/status/triple/reward）
+ * - bilibili.video.admin        管理员命令
  */
-@CommandHeader(name = "bv", aliases = ["bilibili"], permission = "bilibili.video.command")
+@CommandHeader(name = "bv", aliases = ["bilibili"], permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
 object BilibiliVideoCommand {
 
     @CommandBody
@@ -41,7 +46,7 @@ object BilibiliVideoCommand {
     /**
      * 生成二维码地图，供玩家扫码绑定 B 站账号。
      */
-    @CommandBody
+    @CommandBody(permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
     val qrcode = subCommand {
         execute<Player> { player, _, _ ->
             submit(async = true) {
@@ -66,7 +71,7 @@ object BilibiliVideoCommand {
     /**
      * 查看当前玩家的绑定状态与凭证信息。
      */
-    @CommandBody
+    @CommandBody(permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
     val status = subCommand {
         execute<Player> { player, _, _ ->
             submit(async = true) {
@@ -108,7 +113,7 @@ object BilibiliVideoCommand {
      * 参数：
      * - bvid：视频的 BVID，例如 BVxxxxxxxxx
      */
-    @CommandBody
+    @CommandBody(permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
     val triple = subCommand {
         dynamic("bvid") {
             suggestion<Player> { _, _ ->
@@ -146,7 +151,7 @@ object BilibiliVideoCommand {
     /**
      * 基于三连记录登记奖励。
      */
-    @CommandBody
+    @CommandBody(permission = "bilibili.video.use", permissionDefault = PermissionDefault.TRUE)
     val reward = subCommand {
         dynamic("bvid") {
             suggestion<Player> { _, _ ->
@@ -190,8 +195,10 @@ object BilibiliVideoCommand {
      * - /bv admin credential list
      * - /bv admin credential info <label>
      * - /bv admin credential refresh <label>   （占位，刷新逻辑后续实现）
+     * - /bv admin unbind <target>
+     * - /bv admin reload
      */
-    @CommandBody
+    @CommandBody(permission = "bilibili.video.admin", permissionDefault = PermissionDefault.OP)
     val admin = subCommand {
         literal("unbind") {
             dynamic("target") {


### PR DESCRIPTION
- 玩家命令 (qrcode/status/triple/reward) 使用 bilibili.video.use 权限，默认所有人可用
- 管理员命令 (admin) 使用 bilibili.video.admin 权限，默认仅 OP 可用
- 更新 README 命令权限文档
- 版本升级至 2.0.4