### PR TITLE
fix(database): 优化 SQLite 并发性能，解决 SQLITE_BUSY 崩溃问题

### DIFF
--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/config/DatabaseConfig.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/config/DatabaseConfig.kt
@@ -12,7 +12,11 @@ enum class DatabaseType {
 }
 
 data class SqliteSection(
-    val file: String
+    val file: String,
+    val walMode: Boolean = true,
+    val busyTimeout: Long = 5000,
+    val cacheSize: Int = 2000,
+    val synchronous: String = "NORMAL"
 )
 
 data class MysqlSection(
@@ -70,7 +74,11 @@ object DatabaseConfigManager {
         }
 
         val sqlite = SqliteSection(
-            file = file.getString("database.sqlite.file") ?: "bilibili_video.db"
+            file = file.getString("database.sqlite.file") ?: "bilibili_video.db",
+            walMode = file.getBoolean("database.sqlite.wal-mode", true),
+            busyTimeout = file.getLong("database.sqlite.busy-timeout").takeIf { it > 0 } ?: 5000L,
+            cacheSize = file.getInt("database.sqlite.cache-size").takeIf { it > 0 } ?: 2000,
+            synchronous = file.getString("database.sqlite.synchronous") ?: "NORMAL"
         )
 
         val mysql = MysqlSection(

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/database/SqliteWriteExecutor.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/database/SqliteWriteExecutor.kt
@@ -1,0 +1,92 @@
+package online.bingzi.bilibili.video.internal.database
+
+import online.bingzi.bilibili.video.internal.config.DatabaseType
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * SQLite 写操作序列化执行器。
+ *
+ * SQLite 使用文件级锁，多线程并发写入会导致 SQLITE_BUSY 错误。
+ * 此执行器通过单线程队列序列化所有写操作，彻底消除写冲突。
+ *
+ * 对于 MySQL 等其他数据库，写操作直接执行（透传模式）。
+ */
+internal object SqliteWriteExecutor {
+
+    @Volatile
+    private var writeExecutor: ExecutorService? = null
+
+    @Volatile
+    private var sqliteMode: Boolean = false
+
+    private val threadFactory = object : ThreadFactory {
+        private val counter = AtomicInteger(0)
+        override fun newThread(r: Runnable): Thread {
+            return Thread(r, "bv-sqlite-write-${counter.incrementAndGet()}").apply {
+                isDaemon = true
+            }
+        }
+    }
+
+    /**
+     * 初始化执行器。
+     *
+     * @param databaseType 数据库类型，仅 SQLite 时启用序列化
+     */
+    fun initialize(databaseType: DatabaseType) {
+        sqliteMode = (databaseType == DatabaseType.SQLITE)
+        if (sqliteMode && writeExecutor == null) {
+            writeExecutor = Executors.newSingleThreadExecutor(threadFactory)
+        }
+    }
+
+    /**
+     * 同步执行写操作。
+     *
+     * - SQLite 模式：提交到单线程队列执行，阻塞等待结果
+     * - 其他数据库：直接在当前线程执行
+     *
+     * @param operation 写操作
+     * @return 操作结果
+     */
+    fun <T> executeWrite(operation: () -> T): T {
+        return if (sqliteMode) {
+            val executor = writeExecutor
+                ?: throw IllegalStateException("SqliteWriteExecutor not initialized")
+            executor.submit(Callable { operation() }).get()
+        } else {
+            operation()
+        }
+    }
+
+    /**
+     * 关闭执行器，释放资源。
+     *
+     * 等待最多 5 秒让队列中的任务完成。
+     */
+    fun shutdown() {
+        writeExecutor?.let { executor ->
+            executor.shutdown()
+            try {
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    executor.shutdownNow()
+                }
+            } catch (e: InterruptedException) {
+                executor.shutdownNow()
+                Thread.currentThread().interrupt()
+            }
+        }
+        writeExecutor = null
+        sqliteMode = false
+    }
+
+    /**
+     * 检查当前是否为 SQLite 模式。
+     */
+    fun isSqliteMode(): Boolean = sqliteMode
+}

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/BoundAccountRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/BoundAccountRepository.kt
@@ -1,6 +1,7 @@
 package online.bingzi.bilibili.video.internal.repository
 
 import online.bingzi.bilibili.video.internal.database.DatabaseFactory
+import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.BoundAccount
 import online.bingzi.bilibili.video.internal.entity.BoundAccounts
 import org.ktorm.dsl.and
@@ -53,8 +54,8 @@ internal object BoundAccountRepository {
         status: Int = 1,
         createdAt: Long = System.currentTimeMillis(),
         updatedAt: Long = createdAt
-    ): Int {
-        return db.insert(BoundAccounts) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.insert(BoundAccounts) {
             set(it.playerUuid, playerUuid)
             set(it.playerName, playerName)
             set(it.bilibiliMid, bilibiliMid)
@@ -65,8 +66,8 @@ internal object BoundAccountRepository {
         }
     }
 
-    fun updateStatusByPlayerUuid(playerUuid: String, status: Int): Int {
-        return db.update(BoundAccounts) {
+    fun updateStatusByPlayerUuid(playerUuid: String, status: Int): Int = SqliteWriteExecutor.executeWrite {
+        db.update(BoundAccounts) {
             set(it.status, status)
             set(it.updatedAt, System.currentTimeMillis())
             where {
@@ -81,8 +82,8 @@ internal object BoundAccountRepository {
         bilibiliMid: Long,
         bilibiliName: String,
         status: Int = 1
-    ): Int {
-        return db.update(BoundAccounts) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.update(BoundAccounts) {
             set(it.playerName, playerName)
             set(it.bilibiliMid, bilibiliMid)
             set(it.bilibiliName, bilibiliName)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/CredentialRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/CredentialRepository.kt
@@ -1,6 +1,7 @@
 package online.bingzi.bilibili.video.internal.repository
 
 import online.bingzi.bilibili.video.internal.database.DatabaseFactory
+import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.Credential
 import online.bingzi.bilibili.video.internal.entity.Credentials
 import org.ktorm.dsl.eq
@@ -40,8 +41,8 @@ internal object CredentialRepository {
         updatedAt: Long = createdAt,
         expiredAt: Long? = null,
         lastUsedAt: Long? = null
-    ): Int {
-        return db.insert(Credentials) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.insert(Credentials) {
             set(it.label, label)
             set(it.sessData, sessData)
             set(it.biliJct, biliJct)
@@ -66,8 +67,8 @@ internal object CredentialRepository {
         status: Int,
         expiredAt: Long?,
         lastUsedAt: Long?
-    ): Int {
-        return db.update(Credentials) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.update(Credentials) {
             set(it.status, status)
             set(it.expiredAt, expiredAt)
             set(it.lastUsedAt, lastUsedAt)
@@ -86,8 +87,8 @@ internal object CredentialRepository {
         accessKey: String?,
         refreshToken: String?,
         status: Int = 1
-    ): Int {
-        return db.update(Credentials) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.update(Credentials) {
             set(it.sessData, sessData)
             set(it.biliJct, biliJct)
             set(it.bilibiliMid, bilibiliMid)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/RewardRecordRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/RewardRecordRepository.kt
@@ -1,6 +1,7 @@
 package online.bingzi.bilibili.video.internal.repository
 
 import online.bingzi.bilibili.video.internal.database.DatabaseFactory
+import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.RewardRecord
 import online.bingzi.bilibili.video.internal.entity.RewardRecords
 import org.ktorm.dsl.and
@@ -34,8 +35,8 @@ internal object RewardRecordRepository {
         issuedAt: Long = System.currentTimeMillis(),
         context: String? = null,
         failReason: String? = null
-    ): Int {
-        return db.insert(RewardRecords) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.insert(RewardRecords) {
             set(it.playerUuid, playerUuid)
             set(it.playerName, playerName)
             set(it.targetKey, targetKey)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/TripleStatusRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/TripleStatusRepository.kt
@@ -1,6 +1,7 @@
 package online.bingzi.bilibili.video.internal.repository
 
 import online.bingzi.bilibili.video.internal.database.DatabaseFactory
+import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.TripleStatus
 import online.bingzi.bilibili.video.internal.entity.TripleStatuses
 import org.ktorm.dsl.and
@@ -35,8 +36,8 @@ internal object TripleStatusRepository {
         lastCheckTime: Long? = null,
         lastErrorCode: Int? = null,
         lastErrorMessage: String? = null
-    ): Int {
-        return db.insert(TripleStatuses) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.insert(TripleStatuses) {
             set(it.playerUuid, playerUuid)
             set(it.bilibiliMid, bilibiliMid)
             set(it.targetKey, targetKey)
@@ -57,8 +58,8 @@ internal object TripleStatusRepository {
         lastCheckTime: Long,
         lastErrorCode: Int?,
         lastErrorMessage: String?
-    ): Int {
-        return db.update(TripleStatuses) {
+    ): Int = SqliteWriteExecutor.executeWrite {
+        db.update(TripleStatuses) {
             set(it.lastStatus, lastStatus)
             set(it.lastTripleTime, lastTripleTime)
             set(it.lastCheckTime, lastCheckTime)

--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -8,6 +8,14 @@ database:
   sqlite:
     # 数据文件名，代码里再拼到插件 data 目录
     file: "bilibili_video.db"
+    # 启用 WAL (Write-Ahead Logging) 模式，大幅提升并发性能
+    wal-mode: true
+    # 锁等待超时时间(ms)，遇到锁时等待而非立即失败
+    busy-timeout: 5000
+    # 缓存大小(KB)，提升查询性能
+    cache-size: 2000
+    # 同步模式: FULL(最安全)/NORMAL(平衡)/OFF(最快但有风险)
+    synchronous: "NORMAL"
 
   # MySQL 配置（type = mysql 时生效）
   mysql:


### PR DESCRIPTION
- 新增 SqliteWriteExecutor 单线程写操作序列化执行器
- 启用 WAL 模式提升读写并发性能
- 添加 busy_timeout 避免锁等待立即失败
- SQLite 强制单连接池避免多连接写冲突
- 所有 Repository 写操作通过执行器调度
- MySQL 模式不受影响，保持原有配置