### PR TITLE
chore: 升级 TabooLib 与依赖以支持最新 Minecraft

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,8 +49,8 @@ val gsonVersion = "2.11.0"
 val zxingVersion = "3.5.2"
 
 dependencies {
-    compileOnly("ink.ptms.core:v12004:12004:mapped")
-    compileOnly("ink.ptms.core:v12004:12004:universal")
+    compileOnly("ink.ptms.core:v12111:12111:mapped")
+    compileOnly("ink.ptms.core:v12111:12111:universal")
     compileOnly(kotlin("stdlib"))
     compileOnly(kotlin("reflect"))
     compileOnly(fileTree("libs"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    id("io.izzel.taboolib") version "2.0.28"
+    id("io.izzel.taboolib") version "2.0.31"
     id("org.jetbrains.kotlin.jvm") version "2.2.0"
     `maven-publish`
     id("idea")
@@ -34,7 +34,7 @@ taboolib {
         }
     }
     version {
-        taboolib = "6.2.4-1645904"
+        taboolib = "6.2.4-99fb800"
         skipKotlinRelocate = true
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=online.bingzi.bilibili.video
-version=2.0.6-beta1
+version=2.0.6-beta2


### PR DESCRIPTION
## Summary
- 升级 TabooLib Gradle 插件 2.0.28 -> 2.0.31
- 升级 TabooLib 框架 6.2.4-1645904 -> 6.2.4-99fb800
- 升级 ink.ptms.core v12004 -> v12111 (MC 1.21.1.1)
- Bump 版本至 2.0.6-beta2

## Test plan
- [x] `taboolibBuildApi` 构建通过