### PR TITLE
fix: 移除 kotlin-reflect 依赖，修复隔离类加载器下绑定失败 (#20)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     compileOnly("ink.ptms.core:v12111:12111:mapped")
     compileOnly("ink.ptms.core:v12111:12111:universal")
     compileOnly(kotlin("stdlib"))
-    compileOnly(kotlin("reflect"))
     compileOnly(fileTree("libs"))
     compileOnly("org.ktorm:ktorm-core:$ktormVersion")
     compileOnly("org.ktorm:ktorm-support-mysql:$ktormVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=online.bingzi.bilibili.video
-version=2.0.6-beta2
+version=2.0.6-beta3

--- a/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt
@@ -5,6 +5,7 @@ import online.bingzi.bilibili.video.internal.database.DatabaseFactory
 import taboolib.common.platform.Platform
 import taboolib.common.platform.Plugin
 import taboolib.common.platform.function.info
+import taboolib.common.platform.function.warning
 import taboolib.module.metrics.Metrics
 import taboolib.platform.util.bukkitPlugin
 
@@ -29,8 +30,16 @@ object BilibiliVideo : Plugin() {
 
     override fun onDisable() {
         info("正在禁用 BilibiliVideo 插件...")
-        QrLoginService.shutdown()
-        DatabaseFactory.shutdown()
+        try {
+            QrLoginService.shutdown()
+        } catch (e: Throwable) {
+            warning("[BilibiliVideo] QrLoginService 关闭异常: ${e.message}")
+        }
+        try {
+            DatabaseFactory.shutdown()
+        } catch (e: Throwable) {
+            warning("[BilibiliVideo] DatabaseFactory 关闭异常: ${e.message}")
+        }
         info("BilibiliVideo 插件禁用完成！")
     }
 }

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/RuntimeEnv.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/RuntimeEnv.kt
@@ -11,7 +11,6 @@ import taboolib.common.env.RuntimeDependency
  * - Ktorm / HikariCP:数据库访问与连接池
  * - SQLite / MySQL JDBC 驱动
  * - ZXing:二维码生成
- * - kotlin-reflect:Kotlin 反射支持（Ktorm 需要）
  */
 @RuntimeDependencies(
     RuntimeDependency(
@@ -56,9 +55,5 @@ import taboolib.common.env.RuntimeDependency
         value = "!com.google.zxing:core:3.5.2",
         test = "!com.google.zxing.qrcode.QRCodeWriter"
     ),
-    RuntimeDependency(
-        value = "!org.jetbrains.kotlin:kotlin-reflect:2.2.0",
-        test = "!kotlin.reflect.full.KClasses"
-    )
 )
 object RuntimeEnv

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/credential/QrLoginService.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/credential/QrLoginService.kt
@@ -41,11 +41,13 @@ object QrLoginService {
 
     private const val QR_EXPIRE_MILLIS = 180_000L
 
-    private val client: OkHttpClient = OkHttpClient.Builder()
-        .connectTimeout(5, TimeUnit.SECONDS)
-        .readTimeout(8, TimeUnit.SECONDS)
-        .writeTimeout(8, TimeUnit.SECONDS)
-        .build()
+    private val client: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(8, TimeUnit.SECONDS)
+            .writeTimeout(8, TimeUnit.SECONDS)
+            .build()
+    }
 
     private val gson: Gson = Gson()
 

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/BoundAccountEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/BoundAccountEntities.kt
@@ -1,7 +1,7 @@
 package online.bingzi.bilibili.video.internal.entity
 
 import online.bingzi.bilibili.video.internal.DATABASE_TABLE_PREFIX
-import org.ktorm.entity.Entity
+import org.ktorm.dsl.QueryRowSet
 import org.ktorm.schema.Table
 import org.ktorm.schema.int
 import org.ktorm.schema.long
@@ -10,28 +10,36 @@ import org.ktorm.schema.varchar
 /**
  * 玩家与 B 站账号绑定关系。
  */
-internal interface BoundAccount : Entity<BoundAccount> {
+internal data class BoundAccount(
+    val id: Long? = null,
+    val playerUuid: String,
+    val playerName: String,
+    val bilibiliMid: Long,
+    val bilibiliName: String,
+    val status: Int,
+    val createdAt: Long,
+    val updatedAt: Long
+)
 
-    companion object : Entity.Factory<BoundAccount>()
+internal object BoundAccounts : Table<Nothing>(DATABASE_TABLE_PREFIX + "bound_account") {
 
-    var id: Long?
-    var playerUuid: String
-    var playerName: String
-    var bilibiliMid: Long
-    var bilibiliName: String
-    var status: Int
-    var createdAt: Long
-    var updatedAt: Long
+    val id = long("id").primaryKey()
+    val playerUuid = varchar("player_uuid")
+    val playerName = varchar("player_name")
+    val bilibiliMid = long("bilibili_mid")
+    val bilibiliName = varchar("bilibili_name")
+    val status = int("status")
+    val createdAt = long("created_at")
+    val updatedAt = long("updated_at")
 }
 
-internal object BoundAccounts : Table<BoundAccount>(DATABASE_TABLE_PREFIX + "bound_account") {
-
-    val id = long("id").primaryKey().bindTo(BoundAccount::id)
-    val playerUuid = varchar("player_uuid").bindTo(BoundAccount::playerUuid)
-    val playerName = varchar("player_name").bindTo(BoundAccount::playerName)
-    val bilibiliMid = long("bilibili_mid").bindTo(BoundAccount::bilibiliMid)
-    val bilibiliName = varchar("bilibili_name").bindTo(BoundAccount::bilibiliName)
-    val status = int("status").bindTo(BoundAccount::status)
-    val createdAt = long("created_at").bindTo(BoundAccount::createdAt)
-    val updatedAt = long("updated_at").bindTo(BoundAccount::updatedAt)
-}
+internal fun QueryRowSet.toBoundAccount() = BoundAccount(
+    id = this[BoundAccounts.id],
+    playerUuid = this[BoundAccounts.playerUuid]!!,
+    playerName = this[BoundAccounts.playerName]!!,
+    bilibiliMid = this[BoundAccounts.bilibiliMid]!!,
+    bilibiliName = this[BoundAccounts.bilibiliName]!!,
+    status = this[BoundAccounts.status]!!,
+    createdAt = this[BoundAccounts.createdAt]!!,
+    updatedAt = this[BoundAccounts.updatedAt]!!
+)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/CredentialEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/CredentialEntities.kt
@@ -1,7 +1,7 @@
 package online.bingzi.bilibili.video.internal.entity
 
 import online.bingzi.bilibili.video.internal.DATABASE_TABLE_PREFIX
-import org.ktorm.entity.Entity
+import org.ktorm.dsl.QueryRowSet
 import org.ktorm.schema.Table
 import org.ktorm.schema.int
 import org.ktorm.schema.long
@@ -10,38 +10,51 @@ import org.ktorm.schema.varchar
 /**
  * B 站登录凭证信息。
  */
-internal interface Credential : Entity<Credential> {
+internal data class Credential(
+    val id: Long? = null,
+    val label: String,
+    val sessData: String,
+    val biliJct: String,
+    val bilibiliMid: Long? = null,
+    val buvid3: String? = null,
+    val accessKey: String? = null,
+    val refreshToken: String? = null,
+    val status: Int,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val expiredAt: Long? = null,
+    val lastUsedAt: Long? = null
+)
 
-    companion object : Entity.Factory<Credential>()
+internal object Credentials : Table<Nothing>(DATABASE_TABLE_PREFIX + "credential") {
 
-    var id: Long?
-    var label: String
-    var sessData: String
-    var biliJct: String
-    var bilibiliMid: Long?
-    var buvid3: String?
-    var accessKey: String?
-    var refreshToken: String?
-    var status: Int
-    var createdAt: Long
-    var updatedAt: Long
-    var expiredAt: Long?
-    var lastUsedAt: Long?
+    val id = long("id").primaryKey()
+    val label = varchar("label")
+    val sessData = varchar("sessdata")
+    val biliJct = varchar("bili_jct")
+    val bilibiliMid = long("bilibili_mid")
+    val buvid3 = varchar("buvid3")
+    val accessKey = varchar("access_key")
+    val refreshToken = varchar("refresh_token")
+    val status = int("status")
+    val createdAt = long("created_at")
+    val updatedAt = long("updated_at")
+    val expiredAt = long("expired_at")
+    val lastUsedAt = long("last_used_at")
 }
 
-internal object Credentials : Table<Credential>(DATABASE_TABLE_PREFIX + "credential") {
-
-    val id = long("id").primaryKey().bindTo(Credential::id)
-    val label = varchar("label").bindTo(Credential::label)
-    val sessData = varchar("sessdata").bindTo(Credential::sessData)
-    val biliJct = varchar("bili_jct").bindTo(Credential::biliJct)
-    val bilibiliMid = long("bilibili_mid").bindTo(Credential::bilibiliMid)
-    val buvid3 = varchar("buvid3").bindTo(Credential::buvid3)
-    val accessKey = varchar("access_key").bindTo(Credential::accessKey)
-    val refreshToken = varchar("refresh_token").bindTo(Credential::refreshToken)
-    val status = int("status").bindTo(Credential::status)
-    val createdAt = long("created_at").bindTo(Credential::createdAt)
-    val updatedAt = long("updated_at").bindTo(Credential::updatedAt)
-    val expiredAt = long("expired_at").bindTo(Credential::expiredAt)
-    val lastUsedAt = long("last_used_at").bindTo(Credential::lastUsedAt)
-}
+internal fun QueryRowSet.toCredential() = Credential(
+    id = this[Credentials.id],
+    label = this[Credentials.label]!!,
+    sessData = this[Credentials.sessData]!!,
+    biliJct = this[Credentials.biliJct]!!,
+    bilibiliMid = this[Credentials.bilibiliMid],
+    buvid3 = this[Credentials.buvid3],
+    accessKey = this[Credentials.accessKey],
+    refreshToken = this[Credentials.refreshToken],
+    status = this[Credentials.status]!!,
+    createdAt = this[Credentials.createdAt]!!,
+    updatedAt = this[Credentials.updatedAt]!!,
+    expiredAt = this[Credentials.expiredAt],
+    lastUsedAt = this[Credentials.lastUsedAt]
+)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/RewardRecordEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/RewardRecordEntities.kt
@@ -1,38 +1,48 @@
 package online.bingzi.bilibili.video.internal.entity
 
 import online.bingzi.bilibili.video.internal.DATABASE_TABLE_PREFIX
-import org.ktorm.entity.Entity
+import org.ktorm.dsl.QueryRowSet
 import org.ktorm.schema.*
 
 /**
  * 奖励发放记录。
  */
-internal interface RewardRecord : Entity<RewardRecord> {
+internal data class RewardRecord(
+    val id: Long? = null,
+    val playerUuid: String,
+    val playerName: String,
+    val bilibiliMid: Long? = null,
+    val targetKey: String,
+    val rewardKey: String,
+    val status: Int,
+    val issuedAt: Long,
+    val context: String? = null,
+    val failReason: String? = null
+)
 
-    companion object : Entity.Factory<RewardRecord>()
+internal object RewardRecords : Table<Nothing>(DATABASE_TABLE_PREFIX + "reward_record") {
 
-    var id: Long?
-    var playerUuid: String
-    var playerName: String
-    var bilibiliMid: Long?
-    var targetKey: String
-    var rewardKey: String
-    var status: Int
-    var issuedAt: Long
-    var context: String?
-    var failReason: String?
+    val id = long("id").primaryKey()
+    val playerUuid = varchar("player_uuid")
+    val playerName = varchar("player_name")
+    val bilibiliMid = long("bilibili_mid")
+    val targetKey = varchar("target_key")
+    val rewardKey = varchar("reward_key")
+    val status = int("status")
+    val issuedAt = long("issued_at")
+    val context = text("context")
+    val failReason = varchar("fail_reason")
 }
 
-internal object RewardRecords : Table<RewardRecord>(DATABASE_TABLE_PREFIX + "reward_record") {
-
-    val id = long("id").primaryKey().bindTo(RewardRecord::id)
-    val playerUuid = varchar("player_uuid").bindTo(RewardRecord::playerUuid)
-    val playerName = varchar("player_name").bindTo(RewardRecord::playerName)
-    val bilibiliMid = long("bilibili_mid").bindTo(RewardRecord::bilibiliMid)
-    val targetKey = varchar("target_key").bindTo(RewardRecord::targetKey)
-    val rewardKey = varchar("reward_key").bindTo(RewardRecord::rewardKey)
-    val status = int("status").bindTo(RewardRecord::status)
-    val issuedAt = long("issued_at").bindTo(RewardRecord::issuedAt)
-    val context = text("context").bindTo(RewardRecord::context)
-    val failReason = varchar("fail_reason").bindTo(RewardRecord::failReason)
-}
+internal fun QueryRowSet.toRewardRecord() = RewardRecord(
+    id = this[RewardRecords.id],
+    playerUuid = this[RewardRecords.playerUuid]!!,
+    playerName = this[RewardRecords.playerName]!!,
+    bilibiliMid = this[RewardRecords.bilibiliMid],
+    targetKey = this[RewardRecords.targetKey]!!,
+    rewardKey = this[RewardRecords.rewardKey]!!,
+    status = this[RewardRecords.status]!!,
+    issuedAt = this[RewardRecords.issuedAt]!!,
+    context = this[RewardRecords.context],
+    failReason = this[RewardRecords.failReason]
+)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/TripleStatusEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/TripleStatusEntities.kt
@@ -1,7 +1,7 @@
 package online.bingzi.bilibili.video.internal.entity
 
 import online.bingzi.bilibili.video.internal.DATABASE_TABLE_PREFIX
-import org.ktorm.entity.Entity
+import org.ktorm.dsl.QueryRowSet
 import org.ktorm.schema.Table
 import org.ktorm.schema.int
 import org.ktorm.schema.long
@@ -10,32 +10,42 @@ import org.ktorm.schema.varchar
 /**
  * 玩家针对某个视频任务（三连目标）的检测状态。
  */
-internal interface TripleStatus : Entity<TripleStatus> {
+internal data class TripleStatus(
+    val id: Long? = null,
+    val playerUuid: String,
+    val bilibiliMid: Long,
+    val targetKey: String,
+    val targetBvid: String,
+    val lastStatus: Int,
+    val lastTripleTime: Long? = null,
+    val lastCheckTime: Long? = null,
+    val lastErrorCode: Int? = null,
+    val lastErrorMessage: String? = null
+)
 
-    companion object : Entity.Factory<TripleStatus>()
+internal object TripleStatuses : Table<Nothing>(DATABASE_TABLE_PREFIX + "triple_status") {
 
-    var id: Long?
-    var playerUuid: String
-    var bilibiliMid: Long
-    var targetKey: String
-    var targetBvid: String
-    var lastStatus: Int
-    var lastTripleTime: Long?
-    var lastCheckTime: Long?
-    var lastErrorCode: Int?
-    var lastErrorMessage: String?
+    val id = long("id").primaryKey()
+    val playerUuid = varchar("player_uuid")
+    val bilibiliMid = long("bilibili_mid")
+    val targetKey = varchar("target_key")
+    val targetBvid = varchar("target_bvid")
+    val lastStatus = int("last_status")
+    val lastTripleTime = long("last_triple_time")
+    val lastCheckTime = long("last_check_time")
+    val lastErrorCode = int("last_error_code")
+    val lastErrorMessage = varchar("last_error_message")
 }
 
-internal object TripleStatuses : Table<TripleStatus>(DATABASE_TABLE_PREFIX + "triple_status") {
-
-    val id = long("id").primaryKey().bindTo(TripleStatus::id)
-    val playerUuid = varchar("player_uuid").bindTo(TripleStatus::playerUuid)
-    val bilibiliMid = long("bilibili_mid").bindTo(TripleStatus::bilibiliMid)
-    val targetKey = varchar("target_key").bindTo(TripleStatus::targetKey)
-    val targetBvid = varchar("target_bvid").bindTo(TripleStatus::targetBvid)
-    val lastStatus = int("last_status").bindTo(TripleStatus::lastStatus)
-    val lastTripleTime = long("last_triple_time").bindTo(TripleStatus::lastTripleTime)
-    val lastCheckTime = long("last_check_time").bindTo(TripleStatus::lastCheckTime)
-    val lastErrorCode = int("last_error_code").bindTo(TripleStatus::lastErrorCode)
-    val lastErrorMessage = varchar("last_error_message").bindTo(TripleStatus::lastErrorMessage)
-}
+internal fun QueryRowSet.toTripleStatus() = TripleStatus(
+    id = this[TripleStatuses.id],
+    playerUuid = this[TripleStatuses.playerUuid]!!,
+    bilibiliMid = this[TripleStatuses.bilibiliMid]!!,
+    targetKey = this[TripleStatuses.targetKey]!!,
+    targetBvid = this[TripleStatuses.targetBvid]!!,
+    lastStatus = this[TripleStatuses.lastStatus]!!,
+    lastTripleTime = this[TripleStatuses.lastTripleTime],
+    lastCheckTime = this[TripleStatuses.lastCheckTime],
+    lastErrorCode = this[TripleStatuses.lastErrorCode],
+    lastErrorMessage = this[TripleStatuses.lastErrorMessage]
+)

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/BoundAccountRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/BoundAccountRepository.kt
@@ -4,12 +4,8 @@ import online.bingzi.bilibili.video.internal.database.DatabaseFactory
 import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.BoundAccount
 import online.bingzi.bilibili.video.internal.entity.BoundAccounts
-import org.ktorm.dsl.and
-import org.ktorm.dsl.eq
-import org.ktorm.dsl.insert
-import org.ktorm.dsl.update
-import org.ktorm.entity.find
-import org.ktorm.entity.sequenceOf
+import online.bingzi.bilibili.video.internal.entity.toBoundAccount
+import org.ktorm.dsl.*
 
 /**
  * 玩家与 B 站账号绑定仓储。
@@ -20,30 +16,52 @@ internal object BoundAccountRepository {
 
     private val db get() = DatabaseFactory.database()
 
-    private val boundAccounts get() = db.sequenceOf(BoundAccounts)
-
     fun findByPlayerUuid(playerUuid: String, includeInactive: Boolean = false): BoundAccount? {
-        val active = boundAccounts.find { (it.playerUuid eq playerUuid) and (it.status eq 1) }
+        val active = db.from(BoundAccounts)
+            .select()
+            .where { (BoundAccounts.playerUuid eq playerUuid) and (BoundAccounts.status eq 1) }
+            .map { it.toBoundAccount() }
+            .firstOrNull()
         if (active != null || !includeInactive) {
             return active
         }
-        return boundAccounts.find { it.playerUuid eq playerUuid }
+        return db.from(BoundAccounts)
+            .select()
+            .where { BoundAccounts.playerUuid eq playerUuid }
+            .map { it.toBoundAccount() }
+            .firstOrNull()
     }
 
     fun findByBilibiliMid(bilibiliMid: Long, includeInactive: Boolean = false): BoundAccount? {
-        val active = boundAccounts.find { (it.bilibiliMid eq bilibiliMid) and (it.status eq 1) }
+        val active = db.from(BoundAccounts)
+            .select()
+            .where { (BoundAccounts.bilibiliMid eq bilibiliMid) and (BoundAccounts.status eq 1) }
+            .map { it.toBoundAccount() }
+            .firstOrNull()
         if (active != null || !includeInactive) {
             return active
         }
-        return boundAccounts.find { it.bilibiliMid eq bilibiliMid }
+        return db.from(BoundAccounts)
+            .select()
+            .where { BoundAccounts.bilibiliMid eq bilibiliMid }
+            .map { it.toBoundAccount() }
+            .firstOrNull()
     }
 
     fun findByPlayerName(playerName: String, includeInactive: Boolean = false): BoundAccount? {
-        val active = boundAccounts.find { (it.playerName eq playerName) and (it.status eq 1) }
+        val active = db.from(BoundAccounts)
+            .select()
+            .where { (BoundAccounts.playerName eq playerName) and (BoundAccounts.status eq 1) }
+            .map { it.toBoundAccount() }
+            .firstOrNull()
         if (active != null || !includeInactive) {
             return active
         }
-        return boundAccounts.find { it.playerName eq playerName }
+        return db.from(BoundAccounts)
+            .select()
+            .where { BoundAccounts.playerName eq playerName }
+            .map { it.toBoundAccount() }
+            .firstOrNull()
     }
 
     fun insert(

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/CredentialRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/CredentialRepository.kt
@@ -4,12 +4,8 @@ import online.bingzi.bilibili.video.internal.database.DatabaseFactory
 import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.Credential
 import online.bingzi.bilibili.video.internal.entity.Credentials
-import org.ktorm.dsl.eq
-import org.ktorm.dsl.insert
-import org.ktorm.dsl.update
-import org.ktorm.entity.find
-import org.ktorm.entity.sequenceOf
-import org.ktorm.entity.toList
+import online.bingzi.bilibili.video.internal.entity.toCredential
+import org.ktorm.dsl.*
 
 /**
  * B 站凭证仓储。
@@ -18,14 +14,18 @@ internal object CredentialRepository {
 
     private val db get() = DatabaseFactory.database()
 
-    private val credentials get() = db.sequenceOf(Credentials)
-
     fun findByLabel(label: String): Credential? {
-        return credentials.find { it.label eq label }
+        return db.from(Credentials)
+            .select()
+            .where { Credentials.label eq label }
+            .map { it.toCredential() }
+            .firstOrNull()
     }
 
     fun findAll(): List<Credential> {
-        return credentials.toList()
+        return db.from(Credentials)
+            .select()
+            .map { it.toCredential() }
     }
 
     fun insert(
@@ -59,7 +59,11 @@ internal object CredentialRepository {
     }
 
     fun findByBilibiliMid(mid: Long): Credential? {
-        return credentials.find { it.bilibiliMid eq mid }
+        return db.from(Credentials)
+            .select()
+            .where { Credentials.bilibiliMid eq mid }
+            .map { it.toCredential() }
+            .firstOrNull()
     }
 
     fun updateStatusAndUsage(

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/RewardRecordRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/RewardRecordRepository.kt
@@ -4,12 +4,8 @@ import online.bingzi.bilibili.video.internal.database.DatabaseFactory
 import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.RewardRecord
 import online.bingzi.bilibili.video.internal.entity.RewardRecords
-import org.ktorm.dsl.and
-import org.ktorm.dsl.eq
-import org.ktorm.dsl.insert
-import org.ktorm.entity.filter
-import org.ktorm.entity.sequenceOf
-import org.ktorm.entity.toList
+import online.bingzi.bilibili.video.internal.entity.toRewardRecord
+import org.ktorm.dsl.*
 
 /**
  * 奖励记录仓储。
@@ -18,18 +14,18 @@ internal object RewardRecordRepository {
 
     private val db get() = DatabaseFactory.database()
 
-    private val rewardRecords get() = db.sequenceOf(RewardRecords)
-
     fun findAllByPlayerAndTarget(playerUuid: String, targetKey: String): List<RewardRecord> {
-        return rewardRecords
-            .filter { (it.playerUuid eq playerUuid) and (it.targetKey eq targetKey) }
-            .toList()
+        return db.from(RewardRecords)
+            .select()
+            .where { (RewardRecords.playerUuid eq playerUuid) and (RewardRecords.targetKey eq targetKey) }
+            .map { it.toRewardRecord() }
     }
 
     fun findAllByBilibiliMidAndTarget(bilibiliMid: Long, targetKey: String): List<RewardRecord> {
-        return rewardRecords
-            .filter { (it.bilibiliMid eq bilibiliMid) and (it.targetKey eq targetKey) }
-            .toList()
+        return db.from(RewardRecords)
+            .select()
+            .where { (RewardRecords.bilibiliMid eq bilibiliMid) and (RewardRecords.targetKey eq targetKey) }
+            .map { it.toRewardRecord() }
     }
 
     fun findAllByPlayerAndBilibiliMidAndTarget(
@@ -37,13 +33,14 @@ internal object RewardRecordRepository {
         bilibiliMid: Long,
         targetKey: String
     ): List<RewardRecord> {
-        return rewardRecords
-            .filter {
-                (it.playerUuid eq playerUuid) and
-                        (it.bilibiliMid eq bilibiliMid) and
-                        (it.targetKey eq targetKey)
+        return db.from(RewardRecords)
+            .select()
+            .where {
+                (RewardRecords.playerUuid eq playerUuid) and
+                        (RewardRecords.bilibiliMid eq bilibiliMid) and
+                        (RewardRecords.targetKey eq targetKey)
             }
-            .toList()
+            .map { it.toRewardRecord() }
     }
 
     fun insert(

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/TripleStatusRepository.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/repository/TripleStatusRepository.kt
@@ -4,12 +4,8 @@ import online.bingzi.bilibili.video.internal.database.DatabaseFactory
 import online.bingzi.bilibili.video.internal.database.SqliteWriteExecutor
 import online.bingzi.bilibili.video.internal.entity.TripleStatus
 import online.bingzi.bilibili.video.internal.entity.TripleStatuses
-import org.ktorm.dsl.and
-import org.ktorm.dsl.eq
-import org.ktorm.dsl.insert
-import org.ktorm.dsl.update
-import org.ktorm.entity.find
-import org.ktorm.entity.sequenceOf
+import online.bingzi.bilibili.video.internal.entity.toTripleStatus
+import org.ktorm.dsl.*
 
 /**
  * 三连状态仓储。
@@ -18,12 +14,12 @@ internal object TripleStatusRepository {
 
     private val db get() = DatabaseFactory.database()
 
-    private val tripleStatuses get() = db.sequenceOf(TripleStatuses)
-
     fun findByPlayerAndTarget(playerUuid: String, targetKey: String): TripleStatus? {
-        return tripleStatuses.find {
-            (it.playerUuid eq playerUuid) and (it.targetKey eq targetKey)
-        }
+        return db.from(TripleStatuses)
+            .select()
+            .where { (TripleStatuses.playerUuid eq playerUuid) and (TripleStatuses.targetKey eq targetKey) }
+            .map { it.toTripleStatus() }
+            .firstOrNull()
     }
 
     fun insert(


### PR DESCRIPTION
## Summary

- **Ktorm Entity → DSL 模式**: 将所有 `Entity<T>` 接口替换为 `data class`，Repository 层查询从 `sequenceOf/find/filter` 切换为 `db.from().select().where()` DSL，彻底消除对 `kotlin-reflect` 的依赖
- **移除 kotlin-reflect**: 删除 `RuntimeEnv` 中的 RuntimeDependency 声明和 `build.gradle.kts` 中的 `compileOnly(kotlin("reflect"))`
- **修复 onDisable 安全性**: `QrLoginService` 的 `OkHttpClient` 改为 `lazy` 初始化，`BilibiliVideo.onDisable()` 添加 `try-catch` 防止关闭异常中断流程

Closes #20

## Test plan

- [ ] 编译通过 (`./gradlew build` ✅)
- [ ] 确认打包后的 jar 不包含 kotlin-reflect 依赖声明
- [ ] 验证 `/bv qrcode` 二维码登录绑定流程正常工作
- [ ] 验证服务器关闭时不再抛出 `NoClassDefFoundError`