### PR TITLE
fix: 修复隔离类加载下 Ktorm 反射导致的绑定失败

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,68 +207,22 @@ jobs:
 
       - name: 📝 生成更新日志
         id: changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # 获取最新的标签
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          
-          echo "## 📝 更新内容" > CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          
           if [ -n "$LATEST_TAG" ]; then
-            echo "### 自 ${LATEST_TAG} 以来的变更：" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-          
-            # 按类型分组提交记录
-            echo "#### ✨ 新功能" >> CHANGELOG.md
-            FEAT_COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --grep="^feat" 2>/dev/null || echo "")
-            echo "${FEAT_COMMITS:-  - 暂无新功能}" >> CHANGELOG.md
-            echo -e "\n" >> CHANGELOG.md
-          
-            echo "#### 🐛 修复" >> CHANGELOG.md
-            FIX_COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --grep="^fix" 2>/dev/null || echo "")
-            echo "${FIX_COMMITS:-  - 暂无修复}" >> CHANGELOG.md
-            echo -e "\n" >> CHANGELOG.md
-          
-            echo "#### 📚 文档" >> CHANGELOG.md
-            DOCS_COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --grep="^docs" 2>/dev/null || echo "")
-            echo "${DOCS_COMMITS:-  - 暂无文档更新}" >> CHANGELOG.md
-            echo -e "\n" >> CHANGELOG.md
-          
-            echo "#### 🔧 其他变更" >> CHANGELOG.md
-            git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --grep -v "^feat\|^fix\|^docs" | head -20 >> CHANGELOG.md
-            echo -e "\n" >> CHANGELOG.md
+            NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+              -f tag_name="${{ needs.build.outputs.version }}" \
+              -f previous_tag_name="${LATEST_TAG}" \
+              --jq '.body')
           else
-            echo "### 所有变更：" >> CHANGELOG.md
-            echo "" >> CHANGELOG.md
-            git log --pretty=format:"- %s (%h)" | head -50 >> CHANGELOG.md
-            echo -e "\n" >> CHANGELOG.md
+            NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+              -f tag_name="${{ needs.build.outputs.version }}" \
+              --jq '.body')
           fi
-          
-          echo "### 📊 统计" >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          if [ -n "$LATEST_TAG" ]; then
-            COMMITS=$(git rev-list ${LATEST_TAG}..HEAD --count)
-            FILES_CHANGED=$(git diff --stat ${LATEST_TAG}..HEAD | tail -1)
-          else
-            COMMITS=$(git rev-list HEAD --count)
-            FILES_CHANGED=$(git diff --stat $(git rev-list --max-parents=0 HEAD)..HEAD | tail -1)
-          fi
-          echo "- 📊 提交次数: ${COMMITS}" >> CHANGELOG.md
-          echo "- 📂 ${FILES_CHANGED}" >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          
-          # 贡献者
-          echo "### 👥 贡献者" >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          if [ -n "$LATEST_TAG" ]; then
-            git log ${LATEST_TAG}..HEAD --pretty=format:"%an" | sort -u | sed 's/^/- @/' >> CHANGELOG.md
-          else
-            git log --pretty=format:"%an" | sort -u | sed 's/^/- @/' | head -10 >> CHANGELOG.md
-          fi
-          
-          # 保存到输出
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          cat CHANGELOG.md >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: 🚀 发布新版本
@@ -278,88 +232,62 @@ jobs:
           name: BilibiliVideo ${{ needs.build.outputs.version }}
           body: |
             <div align="center">
-            
-            ![TabooLib](https://img.shields.io/badge/TabooLib-6.2.3+-green) ｜![Minecraft](https://img.shields.io/badge/Minecraft-1.8--1.21+-orange) ｜![Java](https://img.shields.io/badge/Java-8+-red) ｜![Build Status](https://img.shields.io/github/actions/workflow/status/BingZi-233/BilibiliVideo/build.yml) ｜![Downloads](https://img.shields.io/github/downloads/BingZi-233/BilibiliVideo/total)
-            
+
+            ![TabooLib](https://img.shields.io/badge/TabooLib-6.2.4+-green) ｜![Minecraft](https://img.shields.io/badge/Minecraft-1.12+-orange) ｜![Java](https://img.shields.io/badge/Java-8+-red) ｜![Build Status](https://img.shields.io/github/actions/workflow/status/BingZi-233/BilibiliVideo/main.yml) ｜![Downloads](https://img.shields.io/github/downloads/BingZi-233/BilibiliVideo/total)
+
             </div>
-            
+
             ---
-            
+
             ${{ steps.changelog.outputs.changelog }}
-            
+
             ---
-            
+
             ## 🚀 快速开始
-            
+
             ### 安装步骤
-            
-            1. **下载插件**
-               ```
-               BilibiliVideo-${{ needs.build.outputs.short_version }}.jar
-               ```
-            
-            2. **放置文件**
-               将 JAR 文件放入服务器的 `plugins` 目录
-            
-            3. **重启服务器**
-               ```bash
-               /reload 或重启服务器
-               ```
-            
-            4. **配置连接**
-               ```bash
-               /bilibili preset list         # 查看可用预设
-               /bilibili preset apply        # 应用预设配置
-               /bilibili connect             # 连接到 Bilibili 服务器
-               /bilibili status              # 查看连接状态
-               ```
-            
+
+            1. **下载插件** — 从本页面下载 `BilibiliVideo-${{ needs.build.outputs.short_version }}.jar`
+            2. **放置文件** — 将 JAR 文件放入服务器的 `plugins` 目录
+            3. **重启服务器** — 插件会自动生成配置文件和数据库
+
+            ### 基本使用
+
+            ```bash
+            /bv qrcode              # 生成 B 站登录二维码，扫码绑定账号
+            /bv status              # 查看账号绑定状态
+            /bv triple <bvid>       # 检测视频三连状态（点赞、投币、收藏）
+            /bv reward <bvid>       # 领取三连奖励
+            ```
+
             ## 📋 系统要求
-            
+
             - **Java**: 8 或更高版本
-            - **服务器**: Bukkit/Spigot/Paper 1.8-1.21+
-            - **内存**: 建议至少 2GB
-            - **Bilibili API**: 支持 Bilibili Open API
-            
+            - **服务端**: Bukkit/Spigot/Paper 1.12+
+            - **数据库**: SQLite（默认，开箱即用）或 MySQL 5.7+
+
             ## 🔗 相关链接
-            
+
             | 资源 | 链接 |
             |------|------|
-            | 📚 文档 | [Wiki](https://github.com/BingZi-233/BilibiliVideo/wiki) |
             | 🐛 问题反馈 | [Issues](https://github.com/BingZi-233/BilibiliVideo/issues) |
             | 💬 讨论交流 | [Discussions](https://github.com/BingZi-233/BilibiliVideo/discussions) |
-            | 📖 配置指南 | [配置文档](https://github.com/BingZi-233/BilibiliVideo/wiki/Configuration) |
-            | 🎯 路线图 | [Roadmap](https://github.com/BingZi-233/BilibiliVideo/projects) |
-            
-            ## ⚠️ 重要提示
-            
-            - 首次使用请仔细阅读 [配置指南](https://github.com/BingZi-233/BilibiliVideo/wiki/Configuration)
-            - 遇到问题请先查看 [FAQ](https://github.com/BingZi-233/BilibiliVideo/wiki/FAQ)
-            - 升级前请备份配置文件
-            
-            ## 💖 支持项目
-            
-            如果这个插件对您有帮助，请考虑：
-            - ⭐ 给项目点个 Star
-            - 🐛 报告问题和建议
-            - 🤝 贡献代码
-            - 📢 向朋友推荐
-            
+
             ---
-            
+
             <div align="center">
-            
-            **感谢使用 BilibiliVideo！** 🎮
-            
+
+            **如果这个插件对你有帮助，请给个 ⭐ Star 支持一下！**
+
             [报告问题](https://github.com/BingZi-233/BilibiliVideo/issues/new/choose) | [请求功能](https://github.com/BingZi-233/BilibiliVideo/issues/new?labels=enhancement) | [加入讨论](https://github.com/BingZi-233/BilibiliVideo/discussions)
-            
+
             </div>
           draft: false
           files: |
             build/libs/*.jar
             !build/libs/*-sources.jar
             !build/libs/*-javadoc.jar
-          generate_release_notes: true
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=online.bingzi.bilibili.video
-version=2.0.6-beta3
+version=2.0.6-beta4

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/RuntimeEnv.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/RuntimeEnv.kt
@@ -27,15 +27,18 @@ import taboolib.common.env.RuntimeDependency
     ),
     RuntimeDependency(
         value = "!org.ktorm:ktorm-core:3.6.0",
-        test = "!org.ktorm.database.Database"
+        test = "!org.ktorm.database.Database",
+        transitive = false
     ),
     RuntimeDependency(
         value = "!org.ktorm:ktorm-support-mysql:3.6.0",
-        test = "!org.ktorm.support.mysql.MySqlDialect"
+        test = "!org.ktorm.support.mysql.MySqlDialect",
+        transitive = false
     ),
     RuntimeDependency(
         value = "!org.ktorm:ktorm-support-sqlite:3.6.0",
-        test = "!org.ktorm.support.sqlite.SQLiteDialect"
+        test = "!org.ktorm.support.sqlite.SQLiteDialect",
+        transitive = false
     ),
     RuntimeDependency(
         value = "!com.zaxxer:HikariCP:4.0.3",

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/BoundAccountEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/BoundAccountEntities.kt
@@ -21,7 +21,10 @@ internal data class BoundAccount(
     val updatedAt: Long
 )
 
-internal object BoundAccounts : Table<Nothing>(DATABASE_TABLE_PREFIX + "bound_account") {
+internal object BoundAccounts : Table<NoEntity>(
+    DATABASE_TABLE_PREFIX + "bound_account",
+    entityClass = NoEntity::class
+) {
 
     val id = long("id").primaryKey()
     val playerUuid = varchar("player_uuid")

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/CredentialEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/CredentialEntities.kt
@@ -26,7 +26,10 @@ internal data class Credential(
     val lastUsedAt: Long? = null
 )
 
-internal object Credentials : Table<Nothing>(DATABASE_TABLE_PREFIX + "credential") {
+internal object Credentials : Table<NoEntity>(
+    DATABASE_TABLE_PREFIX + "credential",
+    entityClass = NoEntity::class
+) {
 
     val id = long("id").primaryKey()
     val label = varchar("label")

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/NoEntity.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/NoEntity.kt
@@ -1,0 +1,11 @@
+package online.bingzi.bilibili.video.internal.entity
+
+import org.ktorm.entity.Entity
+
+/**
+ * Ktorm DSL-only 哑元实体类型。
+ *
+ * 目的：避免使用 Table<Nothing> 触发 Ktorm 在 BaseTable 构造阶段
+ * 对泛型做 Kotlin 反射解析（隔离类加载场景下会导致反射依赖问题）。
+ */
+internal interface NoEntity : Entity<NoEntity>

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/RewardRecordEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/RewardRecordEntities.kt
@@ -20,7 +20,10 @@ internal data class RewardRecord(
     val failReason: String? = null
 )
 
-internal object RewardRecords : Table<Nothing>(DATABASE_TABLE_PREFIX + "reward_record") {
+internal object RewardRecords : Table<NoEntity>(
+    DATABASE_TABLE_PREFIX + "reward_record",
+    entityClass = NoEntity::class
+) {
 
     val id = long("id").primaryKey()
     val playerUuid = varchar("player_uuid")

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/TripleStatusEntities.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/entity/TripleStatusEntities.kt
@@ -23,7 +23,10 @@ internal data class TripleStatus(
     val lastErrorMessage: String? = null
 )
 
-internal object TripleStatuses : Table<Nothing>(DATABASE_TABLE_PREFIX + "triple_status") {
+internal object TripleStatuses : Table<NoEntity>(
+    DATABASE_TABLE_PREFIX + "triple_status",
+    entityClass = NoEntity::class
+) {
 
     val id = long("id").primaryKey()
     val playerUuid = varchar("player_uuid")


### PR DESCRIPTION
## 背景
- `issue #20` 最新反馈（2026-03-03）在 `2.0.6-beta3` 仍出现绑定失败。
- 现场日志核心异常：`NoClassDefFoundError: Could not initialize class ...BoundAccounts`。

## 变更内容
1. 避免 Ktorm 在表初始化阶段触发反射链
- 新增 `NoEntity : Entity<NoEntity>` 作为 DSL-only 哑元实体。
- 将以下表定义从 `Table<Nothing>` 调整为 `Table<NoEntity>(..., entityClass = NoEntity::class)`：
  - `BoundAccounts`
  - `Credentials`
  - `RewardRecords`
  - `TripleStatuses`

2. 收紧运行时依赖加载
- 在 `RuntimeDependency` 中将以下依赖设置为 `transitive = false`：
  - `org.ktorm:ktorm-core:3.6.0`
  - `org.ktorm:ktorm-support-mysql:3.6.0`
  - `org.ktorm:ktorm-support-sqlite:3.6.0`

3. 版本
- `gradle.properties` 调整为 `2.0.6-beta4`

## 验证
- 本地执行：`./gradlew clean taboolibBuildApi` 通过。
- 产物：`build/libs/BilibiliVideo-2.0.6-beta4.jar`
- 反编译验证 `BoundAccounts` 构造器已使用 `NoEntity::class`，不再是 `Void::class`。
