### PR TITLE
新增 PlaceholderAPI 扩展支持及动态注册机制

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,14 @@ plugins {
     id("idea")
 }
 
+repositories {
+    mavenCentral()
+    maven {
+        name = "placeholderapi"
+        url = uri("https://repo.extendedclip.com/content/repositories/placeholderapi/")
+    }
+}
+
 taboolib {
     env {
         install(Basic)
@@ -47,6 +55,7 @@ val okhttpVersion = "4.12.0"
 val okioVersion = "3.6.0"
 val gsonVersion = "2.11.0"
 val zxingVersion = "3.5.2"
+val placeholderapi = "2.11.5"
 
 dependencies {
     compileOnly("ink.ptms.core:v12111:12111:mapped")
@@ -63,6 +72,7 @@ dependencies {
     compileOnly("com.squareup.okio:okio-jvm:$okioVersion")
     compileOnly("com.google.code.gson:gson:$gsonVersion")
     compileOnly("com.google.zxing:core:$zxingVersion")
+    compileOnly("me.clip:placeholderapi:$placeholderapi")
 }
 
 tasks.withType<JavaCompile> {

--- a/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt
@@ -20,7 +20,7 @@ object BilibiliVideo : Plugin() {
     override fun onEnable() {
         info("正在启动 BilibiliVideo 插件...")
         DatabaseFactory.initFromConfig()
-        // 注册 PlaceholderAPI 的 BiliBiliVideoExpansion 类
+        // 注册 PlaceholderAPI 的 PlaceholderExpansion 类
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             PlaceholderRegistry.init()
         }

--- a/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt
@@ -2,6 +2,8 @@ package online.bingzi.bilibili.video
 
 import online.bingzi.bilibili.video.internal.credential.QrLoginService
 import online.bingzi.bilibili.video.internal.database.DatabaseFactory
+import online.bingzi.bilibili.video.internal.placeholder.PlaceholderRegistry
+import org.bukkit.Bukkit
 import taboolib.common.platform.Platform
 import taboolib.common.platform.Plugin
 import taboolib.common.platform.function.info
@@ -18,6 +20,10 @@ object BilibiliVideo : Plugin() {
     override fun onEnable() {
         info("正在启动 BilibiliVideo 插件...")
         DatabaseFactory.initFromConfig()
+        // 注册 PlaceholderAPI 的 BiliBiliVideoExpansion 类
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            PlaceholderRegistry.init()
+        }
         info("BilibiliVideo 插件启动完成！")
     }
 

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/placeholder/PlaceholderExpansion.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/placeholder/PlaceholderExpansion.kt
@@ -1,0 +1,114 @@
+package online.bingzi.bilibili.video.internal.placeholder
+
+import me.clip.placeholderapi.expansion.Configurable
+import me.clip.placeholderapi.expansion.PlaceholderExpansion
+import online.bingzi.bilibili.video.internal.service.BindingService
+import online.bingzi.bilibili.video.internal.service.CredentialService
+import org.bukkit.OfflinePlayer
+
+/**
+ * PlaceholderAPI 占位符扩展！
+ * @author MaddyJace
+ */
+class PlaceholderExpansion : PlaceholderExpansion(), Configurable {
+
+    /**
+     * 默认配置
+     */
+    companion object {
+        private val DEFAULTS = mapOf(
+            "status.disabled" to "禁用",
+            "status.normal" to "正常",
+            "status.expired" to "过期",
+            "status.unknown" to "未知(%status%)",
+            "boolean.true" to "yes",
+            "boolean.false" to "no",
+            "options.null_value" to "null",
+            "options.triple_error" to "default"
+        )
+    }
+
+    override fun getDefaults(): Map<String, Any> = DEFAULTS
+    override fun getIdentifier(): String = "bilibilivideo"
+    override fun getAuthor(): String = "MaddyJace"
+    override fun getVersion(): String = "1.0.0"
+
+    override fun onRequest(player: OfflinePlayer?, identifier: String): String? {
+        val nullFallback = getString("options.null_value", "null")
+        val p = player?.player ?: return nullFallback
+
+        val list = splitString(identifier)
+        if (list.isEmpty()) return nullFallback
+
+        val firstParam = list[0].lowercase()
+
+        // 1. 绑定信息
+        val binding = BindingService.getBoundAccount(player.uniqueId.toString())
+        if (binding != null) {
+            when (firstParam) {
+                "name" -> return binding.playerName
+                "uid" -> return binding.bilibiliMid.toString()
+                "nickname" -> return binding.bilibiliName
+            }
+        }
+
+        // 2. 凭证状态
+        val credential = CredentialService.getCredentialInfo(p)
+        if (credential != null) {
+            val statusText = when (credential.status) {
+                0 -> getString("status.disabled", "禁用")
+                1 -> getString("status.normal", "正常")
+                2 -> getString("status.expired", "过期")
+                else -> getString("status.unknown", "未知(%status%)")
+                    ?.replace("%status%", credential.status.toString())
+            }
+
+            when (firstParam) {
+                "status" -> return statusText
+                "label" -> return credential.label
+                "binduid" -> {
+                    val mid = credential.bilibiliMid?.toString()
+                        ?: binding?.bilibiliMid?.toString()
+                        ?: "nouid"
+                    return mid
+                }
+            }
+        }
+
+        // 3. 三连检查
+        if (firstParam == "triple" && list.size >= 3) {
+            val type = list[1].lowercase()
+            val bvid = list[2]
+            val result = CredentialService.checkTripleByPlayer(p, bvid)
+
+            val status = result.tripleStatus
+            if (!result.success || status == null) {
+                val customError = getString("options.triple_error", "default")
+                return if (customError.equals("default", true)) result.message else result.message
+            }
+
+            val boolTrue = getString("boolean.true", "yes")
+            val boolFalse = getString("boolean.false", "no")
+
+            return when (type) {
+                "liked" -> if (status.liked) boolTrue else boolFalse
+                "coincount" -> status.coinCount.toString()
+                "favoured" -> if (status.favoured) boolTrue else boolFalse
+                "istriple" -> if (status.isTriple) boolTrue else boolFalse
+                else -> nullFallback
+            }
+        }
+
+        return nullFallback
+    }
+
+    private fun splitString(input: String): List<String> {
+        val regex = "_(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)".toRegex()
+        return input.split(regex).map { part ->
+            if (part.startsWith("\"") && part.endsWith("\"") && part.length >= 2) {
+                part.substring(1, part.length - 1)
+            } else part
+        }
+    }
+
+}

--- a/src/main/kotlin/online/bingzi/bilibili/video/internal/placeholder/PlaceholderRegistry.kt
+++ b/src/main/kotlin/online/bingzi/bilibili/video/internal/placeholder/PlaceholderRegistry.kt
@@ -1,0 +1,17 @@
+package online.bingzi.bilibili.video.internal.placeholder
+
+
+/**
+ * 反射注册 PlaceholderAPI 占位符！
+ * @author MaddyJace
+ */
+internal object PlaceholderRegistry {
+    fun init() {
+        try {
+            val clazz = Class.forName("online.bingzi.bilibili.video.internal.placeholder.PlaceholderExpansion")
+            val expansion = clazz.getDeclaredConstructor().newInstance()
+            val registerMethod = clazz.getMethod("register")
+            registerMethod.invoke(expansion)
+        } catch (_: Throwable) { }
+    }
+}


### PR DESCRIPTION
## 标题：新增 PlaceholderAPI 扩展支持及动态注册机制

### 概览
我在 minebbs 描述上看到是支持 PlaceholderAPI 占位符，阅读代码后发现并没有实现该功能，本次提交为插件集成了 PAPI 扩展，允许管理员和开发者通过占位符实时调用玩家的 Bilibili 绑定状态、凭据信息及视频交互数据(三连状态)。

### 核心修改

#### 1. 依赖管理
* 在 [build.gradle.kts](https://github.com/MaddyJace/BilibiliVideo/blob/1fca9e1abf4490f3c44ffc3f74a15b1588173d00/build.gradle.kts) 中引入了 PlaceholderAPI 仓库及编译时依赖。

#### 2. 占位符实现 ([PlaceholderExpansion.kt](https://github.com/MaddyJace/BilibiliVideo/blob/1fca9e1abf4490f3c44ffc3f74a15b1588173d00/src/main/kotlin/online/bingzi/bilibili/video/internal/DatabaseTablePrefix.kt))
* **基础信息**：支持 `%bilibilivideo_name%`, `%bilibilivideo_uid%`, `%bilibilivideo_nickname%`。
*  **凭据状态**：支持 `%bilibilivideo_status%`, `%bilibilivideo_label%`, `%bilibilivideo_binduid%`。
*  **三连检查**：可以检查根据config.yml配置中的视频BV号三联状况：
    * `%bilibilivideo_triple_liked_<bvid>%` - 是否点赞
    * `%bilibilivideo_triple_coincount_<bvid>%` - 投币数
    * `%bilibilivideo_triple_favoured_<bvid>%` - 是否收藏
    * `%bilibilivideo_triple_istriple_<bvid>%` - 是否三连
* **可配置化**：通过继承 `Configurable` 接口，支持用户在 plugins/PlaceholderAPI/config.yml 的配置文件中自定义状态显示文。 例如:  
* ```yaml
  bilibilivideo:
    status:
      disabled: 禁用
      normal: 正常
      expired: 过期
      unknown: 未知(%status%)
    boolean:
      'true': 'yes'
      'false': 'no'
    options:
      null_value: 'null'
      triple_error: default

#### 3. 兼容性设计 ([PlaceholderRegistry.kt](https://github.com/MaddyJace/BilibiliVideo/blob/1fca9e1abf4490f3c44ffc3f74a15b1588173d00/src/main/kotlin/online/bingzi/bilibili/video/internal/placeholder/PlaceholderRegistry.kt))
* **注册机制**：反射机制进行动态注册，避免硬编码依赖。
* **软依赖处理**：插件启动时会自动检测服务器是否安装 PlaceholderAPI。若未安装，则静默跳过注册流程，确保插件在无 PAPI 环境下依然能正常初始化。

#### 4. 生命周期集成 ([BilibiliVideo.kt](https://github.com/MaddyJace/BilibiliVideo/blob/1fca9e1abf4490f3c44ffc3f74a15b1588173d00/src/main/kotlin/online/bingzi/bilibili/video/BilibiliVideo.kt))
* 在 `onEnable` 阶段增加 PlaceholderAPI 存在并调用 `PlaceholderRegistry.init()` 完成自动化挂载。

### 占位符列表对照表

| 占位符 | 描述 |
| :--- | :--- |
| `%bilibilivideo_name%` | 返回与 Bilibili 绑定关联的 Minecraft 玩家名称 |
| `%bilibilivideo_uid%` | 返回玩家绑定的 Bilibili UID (Mid) |
| `%bilibilivideo_status%` | 返回玩家凭据的状态（正常、过期、禁用） |
| `%bilibilivideo_triple_liked_<bvid>%` | 返回玩家是否已点赞指定视频 (`yes`/`no`) |
| `%bilibilivideo_triple_istriple_<bvid>%` | 返回玩家是否完成“一键三连” |

---

**提交者**: MaddyJace (@MaddyJace)